### PR TITLE
Improve Promise impl to make the test valid without adding onSubscribeCalled

### DIFF
--- a/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
+++ b/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
@@ -908,7 +908,7 @@ public class TestEnvironment {
         // we add the value to the queue such to wake up any expectCompletion which was triggered before complete() was called
         abq.add(value);
       } else {
-        env.flop(String.format("Cannot complete a promise more than once! Present value: %s, attempted to set: %s", value));
+        env.flop(String.format("Cannot complete a promise more than once! Present value: %s, attempted to set: %s", _value.get(), value));
       }
     }
 

--- a/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
+++ b/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
@@ -907,6 +907,8 @@ public class TestEnvironment {
       if (_value.compareAndSet(null, value)) {
         // we add the value to the queue such to wake up any expectCompletion which was triggered before complete() was called
         abq.add(value);
+      } else {
+        env.flop(String.format("Cannot complete a promise more than once! Present value: %s", value));
       }
     }
 

--- a/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
+++ b/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
@@ -572,8 +572,6 @@ public class TestEnvironment {
 
   public static class ManualSubscriberWithSubscriptionSupport<T> extends ManualSubscriber<T> {
 
-    private final AtomicBoolean onSubscribeCalled = new AtomicBoolean();
-
     public ManualSubscriberWithSubscriptionSupport(TestEnvironment env) {
       super(env);
     }
@@ -591,7 +589,7 @@ public class TestEnvironment {
     @Override
     public void onComplete() {
       env.debug(this + "::onComplete()");
-      if (onSubscribeCalled.get()) {
+      if (subscription.isCompleted()) {
         super.onComplete();
       } else {
         env.flop("Subscriber::onComplete() called before Subscriber::onSubscribe");
@@ -603,7 +601,6 @@ public class TestEnvironment {
       env.debug(String.format("%s::onSubscribe(%s)", this, s));
       if (!subscription.isCompleted()) {
         subscription.complete(s);
-        onSubscribeCalled.set(true);
       } else {
         env.flop("Subscriber::onSubscribe called on an already-subscribed Subscriber");
       }
@@ -612,7 +609,7 @@ public class TestEnvironment {
     @Override
     public void onError(Throwable cause) {
       env.debug(String.format("%s::onError(%s)", this, cause));
-      if (onSubscribeCalled.get()) {
+      if (subscription.isCompleted()) {
         super.onError(cause);
       } else {
         env.flop(cause, String.format("Subscriber::onError(%s) called before Subscriber::onSubscribe", cause));
@@ -806,7 +803,7 @@ public class TestEnvironment {
     public void expectCancelling(long timeoutMillis) throws InterruptedException {
       cancelled.expectClose(timeoutMillis, "Did not receive expected cancelling of upstream subscription");
     }
-    
+
     public boolean isCancelled() throws InterruptedException {
       return cancelled.isClosed();
     }

--- a/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
+++ b/tck/src/main/java/org/reactivestreams/tck/TestEnvironment.java
@@ -908,7 +908,7 @@ public class TestEnvironment {
         // we add the value to the queue such to wake up any expectCompletion which was triggered before complete() was called
         abq.add(value);
       } else {
-        env.flop(String.format("Cannot complete a promise more than once! Present value: %s", value));
+        env.flop(String.format("Cannot complete a promise more than once! Present value: %s, attempted to set: %s", value));
       }
     }
 


### PR DESCRIPTION
Improve Promise impl to make the test valid without adding onSubscribeCalled

This is a PR into a PR to resolve https://github.com/reactive-streams/reactive-streams-jvm/pull/423/files 

Resolves https://github.com/reactive-streams/reactive-streams-jvm/issues/422